### PR TITLE
support kernels newer than v4.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is an implementation of the LEDBAT congestion control algorithm over TCP
 using the Linux kernel modular congestion control framework.
 
-The current version is updated to compile under Linux kernel 4.9.x versions. A version
+The current version is updated to compile under Linux kernel 4.19.x versions. A version
 working with kernels up to 3.3.x is tagged with a "3.3" tag. The module has not been tested
 with version in between.
 

--- a/src/tcp_ledbat.c
+++ b/src/tcp_ledbat.c
@@ -504,11 +504,24 @@ static void tcp_ledbat_pkts_acked(struct sock *sk,
 
 }
 
+/**
+ * tcp_ledbat_undo_cwnd
+ * required starting kernel v4.10, see
+ * kernel commmit e97991832a4ea4a5f47d65f068a4c966a2eb5730
+ */
+static u32 tcp_ledbat_undo_cwnd(struct sock *sk)
+{
+	/* this is the default v4.9 behavior */
+	const struct tcp_sock *tp = tcp_sk(sk);
+	return max(tp->snd_cwnd, tp->snd_ssthresh << 1);
+}
+
 static struct tcp_congestion_ops tcp_ledbat = {
 	.init = tcp_ledbat_init,
 	.ssthresh = tcp_ledbat_ssthresh,
 	.cong_avoid = tcp_ledbat_cong_avoid,
 	.pkts_acked = tcp_ledbat_pkts_acked,
+	.undo_cwnd = tcp_ledbat_undo_cwnd,
 	.release = tcp_ledbat_release,
 
 	.owner = THIS_MODULE,


### PR DESCRIPTION
this works with v4.19.x at least

see https://github.com/torvalds/linux/commit/e97991832a4ea4a5f47d65f068a4c966a2eb5730