### PR TITLE
stop using deprecated SUBDIRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 This is an implementation of the LEDBAT congestion control algorithm over TCP
 using the Linux kernel modular congestion control framework.
 
-The current version is updated to compile under Linux kernel 4.19.x versions. A version
-working with kernels up to 3.3.x is tagged with a "3.3" tag. The module has not been tested
-with version in between.
+The current version is updated to compile under Linux kernel 5.7.x versions. A version
+working with kernels up to 3.3.x is tagged with a "3.3" tag. It has previously been tested with 4.9.x and 4.19.x as well.
 
 The module currently loads properly but it has *not* been tested thoroughly.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ IDIR= /lib/modules/$(shell uname -r)/kernel/net/ipv4/
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 default:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) KBUILD_EXTMOD=$(PWD) modules
 
 install:
 	install -v -m 644 tcp_ledbat.ko $(IDIR)


### PR DESCRIPTION
from https://www.mail-archive.com/debian-kernel@lists.debian.org/msg117334.html

> This is the problem: the SUBDIRS variable in Kbuild has been deprecated
> for years, warned about since Linux 5.0, and is unsupported starting
> with Linux 5.4.  The distributor for this module (which doesn't seem to
> be Debian) needs to replace "SUBDIRS" with "KBUILD_EXTMOD".