### PR TITLE
Updated Makefile to compile module on 5.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is an implementation of the LEDBAT congestion control algorithm over TCP
 using the Linux kernel modular congestion control framework.
 
-The current version is updated to compile under Linux kernel 4.19.x versions. A version
+The current version is updated to compile under Linux kernel 5.4.x versions. A version
 working with kernels up to 3.3.x is tagged with a "3.3" tag. The module has not been tested
 with version in between.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ IDIR= /lib/modules/$(shell uname -r)/kernel/net/ipv4/
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 default:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 install:
 	install -v -m 644 tcp_ledbat.ko $(IDIR)


### PR DESCRIPTION
SUBDIRS flag has now been deprecated in favor of M, see https://github.com/openzfs/zfs/issues/8257. I have tracked that the M Make flag is present at kernels as back 2.x, so it should be a safe eddition.